### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/calteran/oliframe/compare/v0.1.0...HEAD)
 
+## [0.1.1](https://github.com/calteran/oliframe/compare/v0.1.0...v0.1.1) - 2024-01-25
+
+### Fixed
+- dependabot.yml syntax
+
+### Other
+- *(deps)* bump rayon from 1.8.0 to 1.8.1
+- *(deps)* bump clap from 4.4.12 to 4.4.18
+- *(deps)* bump image from 0.24.7 to 0.24.8
+- add roadmap section to README.md; mention future --watch option
+
 ## [0.1.0](https://github.com/calteran/oliframe/releases/tag/v0.1.0) - 2024-01-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "oliframe"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "csscolorparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "oliframe"
 description = "Add a simple border to one or more images"
 repository = "https://github.com/calteran/oliframe"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
## 🤖 New release
* `oliframe`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/calteran/oliframe/compare/v0.1.0...v0.1.1) - 2024-01-25

### Fixed
- dependabot.yml syntax

### Other
- *(ci)* use PAT to allow `release-plz` PR to trigger workflows
- *(ci)* don't require CI on `release-plz` release branches
- *(ci)* remove unneeded push CI triggers
- change method to add as library in `README.md`
- *(deps)* bump rayon from 1.8.0 to 1.8.1
- *(deps)* bump clap from 4.4.17 to 4.4.18
- add roadmap section to README.md; mention future --watch option
- *(deps)* bump image from 0.24.7 to 0.24.8
- *(deps)* bump clap from 4.4.12 to 4.4.17
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).