### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.2](https://github.com/calteran/oliframe/compare/v0.1.1...v0.1.2) - 2024-02-27
 
 ### Other
-- Merge branch 'main' into develop
 - *(deps)* bump image from 0.24.8 to 0.24.9
-- *(deps)* bump clap from 4.5.0 to 4.5.1
-- *(deps)* bump clap from 4.4.18 to 4.5.0
+- *(deps)* bump clap from 4.4.18 to 4.5.1
 
 ## [0.1.1](https://github.com/calteran/oliframe/compare/v0.1.0...v0.1.1) - 2024-01-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/calteran/oliframe/compare/v0.1.0...HEAD)
 
+## [0.1.2](https://github.com/calteran/oliframe/compare/v0.1.1...v0.1.2) - 2024-02-27
+
+### Other
+- Merge branch 'main' into develop
+- *(deps)* bump image from 0.24.8 to 0.24.9
+- *(deps)* bump clap from 4.5.0 to 4.5.1
+- *(deps)* bump clap from 4.4.18 to 4.5.0
+
 ## [0.1.1](https://github.com/calteran/oliframe/compare/v0.1.0...v0.1.1) - 2024-01-25
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "oliframe"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "clap",
  "csscolorparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "oliframe"
 description = "Add a simple border to one or more images"
 repository = "https://github.com/calteran/oliframe"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
## 🤖 New release
* `oliframe`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/calteran/oliframe/compare/v0.1.1...v0.1.2) - 2024-02-27

### Other
- Merge branch 'main' into develop
- *(deps)* bump image from 0.24.8 to 0.24.9
- *(deps)* bump clap from 4.5.0 to 4.5.1
- *(deps)* bump clap from 4.4.18 to 4.5.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).