### PR TITLE
chore: release v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/calteran/oliframe/compare/v0.1.0...HEAD)
 
+## [0.1.6](https://github.com/calteran/oliframe/compare/v0.1.5...v0.1.6) - 2024-07-01
+
+### Other
+- *(deps)* bump clap from 4.5.7 to 4.5.8
+- *(deps)* bump clap from 4.5.4 to 4.5.7
+
 ## [0.1.5](https://github.com/calteran/oliframe/compare/v0.1.4...v0.1.5) - 2024-04-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.6](https://github.com/calteran/oliframe/compare/v0.1.5...v0.1.6) - 2024-07-01
 
 ### Other
-- *(deps)* bump clap from 4.5.7 to 4.5.8
-- *(deps)* bump clap from 4.5.4 to 4.5.7
+- *(deps)* bump clap from 4.5.4 to 4.5.8
 
 ## [0.1.5](https://github.com/calteran/oliframe/compare/v0.1.4...v0.1.5) - 2024-04-29
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,7 +665,7 @@ dependencies = [
 
 [[package]]
 name = "oliframe"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "clap",
  "csscolorparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "oliframe"
 description = "Add a simple border to one or more images"
 repository = "https://github.com/calteran/oliframe"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
## 🤖 New release
* `oliframe`: 0.1.5 -> 0.1.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.6](https://github.com/calteran/oliframe/compare/v0.1.5...v0.1.6) - 2024-07-01

### Other
- *(deps)* bump clap from 4.5.7 to 4.5.8
- *(deps)* bump clap from 4.5.4 to 4.5.7
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).