### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -6,9 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/calteran/oliframe/compare/v0.1.0...HEAD)
 
+## [0.2.0](https://github.com/calteran/oliframe/compare/v0.1.7...v0.2.0) - 2024-09-06
+
+### Added
+
+- [**breaking**] complete rewrite of the project, including improved error handling, better CLI, and more frame
+  configuration options
+- Full test coverage
+
 ## [0.1.7](https://github.com/calteran/oliframe/compare/v0.1.6...v0.1.7) - 2024-08-19
 
 ### Other
+
 - change to monthly, grouped dependabot updates
 - Simplify deny.toml and update allowed licenses
 - *(deps)* bump csscolorparser from 0.6.2 to 0.7.0
@@ -19,21 +29,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.6](https://github.com/calteran/oliframe/compare/v0.1.5...v0.1.6) - 2024-07-01
 
 ### Other
+
 - *(deps)* bump clap from 4.5.4 to 4.5.8
 
 ## [0.1.5](https://github.com/calteran/oliframe/compare/v0.1.4...v0.1.5) - 2024-04-29
 
 ### Fixed
+
 - skip alpha processing on JPEG outputs
 
 ## [0.1.4](https://github.com/calteran/oliframe/compare/v0.1.3...v0.1.4) - 2024-04-14
 
 ### Fixed
+
 - downgrade `image` due to upline change to `zune-jpeg`
 
 ## [0.1.3](https://github.com/calteran/oliframe/compare/v0.1.2...v0.1.3) - 2024-04-08
 
 ### Other
+
 - *(deps)* bump clap from 4.5.1 to 4.5.4
 - *(deps)* bump image from 0.24.9 to 0.25.1
 - *(deps)* bump rayon from 1.8.1 to 1.10.0
@@ -41,15 +55,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.2](https://github.com/calteran/oliframe/compare/v0.1.1...v0.1.2) - 2024-02-27
 
 ### Other
+
 - *(deps)* bump image from 0.24.8 to 0.24.9
 - *(deps)* bump clap from 4.4.18 to 4.5.1
 
 ## [0.1.1](https://github.com/calteran/oliframe/compare/v0.1.0...v0.1.1) - 2024-01-25
 
 ### Fixed
+
 - dependabot.yml syntax
 
 ### Other
+
 - *(deps)* bump rayon from 1.8.0 to 1.8.1
 - *(deps)* bump clap from 4.4.12 to 4.4.18
 - *(deps)* bump image from 0.24.7 to 0.24.8
@@ -58,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0](https://github.com/calteran/oliframe/releases/tag/v0.1.0) - 2024-01-16
 
 ### Added
+
 - reexport `image` and `csscolorparser::Color`
 - Add support for border color in add_border function
 - Rename project to "oliframe" and update references
@@ -67,6 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add clap dependency and parser module
 
 ### Other
+
 - split workflow into 2 jobs; add cargo deny
 - *(deps)* remove indicatif & atty from dependencies
 - setup github actions & dependabot

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "oliframe"
-version = "0.1.7"
+version = "0.2.0"
 dependencies = [
  "clap",
  "csscolorparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "oliframe"
 description = "Add a simple border to one or more images"
 repository = "https://github.com/calteran/oliframe"
-version = "0.1.7"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
## 🤖 New release
* `oliframe`: 0.1.7 -> 0.2.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/calteran/oliframe/compare/v0.1.7...v0.2.0) - 2024-09-06

### Added
- [**breaking**] significant rewrite, including new options, frame processing, testing & documentation ([#63](https://github.com/calteran/oliframe/pull/63))
- [**breaking**] margin values are always relative
- [**breaking**] build valid configuration from cli options
- [**breaking**] new configuration & geometry structures
- [**breaking**] rework & expand command-line interface

### Fixed
- remove junk file detection (un-needed)
- correctly handle subfolders in output paths
- screen junk files
- margins & frame size with `--ar` now correctly calculated
- update `.gitignore` to allow PNG sample files
- remove unneeded `unit` parameter from `Size`

### Other
- *(deps)* update dependencies
- add codecov badge
- add codecov token
- fix clippy lints in test modules
- acknowledge duplicate `windows-sys` in deps
- update readme and examples
- replace old sample files with test images
- spelling & grammar lints
- clippy lints
- *(ci)* add coverage reporting
- improved test coverage
- image processing
- streamline file collection
- [**breaking**] remove old code
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).