### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/calteran/oliframe/compare/v0.1.0...HEAD)
 
+## [0.2.1](https://github.com/calteran/oliframe/compare/v0.2.0...v0.2.1) - 2024-10-02
+
+### Other
+
+- *(deps)* bump the crate-deps group with 4 updates
+
 ## [0.2.0](https://github.com/calteran/oliframe/compare/v0.1.7...v0.2.0) - 2024-09-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "oliframe"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "csscolorparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "oliframe"
 description = "Add a simple border to one or more images"
 repository = "https://github.com/calteran/oliframe"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![oliframe](https://github.com/calteran/oliframe/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/calteran/oliframe/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/oliframe.svg)](https://crates.io/crates/oliframe)
 [![docs.rs](https://docs.rs/oliframe/badge.svg)](https://docs.rs/oliframe)
-[![codecov](https://codecov.io/github/calteran/oliframe/graph/badge.svg?token=8IWPNES6K2)](https://codecov.io/github/calteran/oliframe)
 [![MIT license](https://img.shields.io/badge/License-MIT-blue.svg)](https://calteran.mit-license.org/)
 
 **Oliframe** is a command-line tool written in [Rust](https://www.rust-lang.org) to add simple colored frames (borders)


### PR DESCRIPTION
## 🤖 New release
* `oliframe`: 0.2.0 -> 0.2.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/calteran/oliframe/compare/v0.2.0...v0.2.1) - 2024-10-02

### Other

- dependency updates ([#68](https://github.com/calteran/oliframe/pull/68))
- remove codecov job due to repeated token issues
- *(deps)* bump the crate-deps group with 4 updates
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).