### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/calteran/oliframe/compare/v0.1.0...HEAD)
 
+## [0.2.2](https://github.com/calteran/oliframe/compare/v0.2.1...v0.2.2) - 2024-11-05
+
+### Other
+
+- Merge branch 'develop' into dependabot/cargo/develop/crate-deps-fc6a7a0e96
+- remove docs badge
+- *(deps)* bump the crate-deps group with 4 updates
+
 ## [0.2.1](https://github.com/calteran/oliframe/compare/v0.2.0...v0.2.1) - 2024-10-02
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
-- Merge branch 'develop' into dependabot/cargo/develop/crate-deps-fc6a7a0e96
-- remove docs badge
-- *(deps)* bump the crate-deps group with 4 updates
+- *(deps)* bump clap from 4.5.19 to 4.5.20
+- *(deps)* bump image from 0.25.2 to 0.25.4
+- *(deps)* bump regex from 1.11.0 to 1.11.1
+- *(deps)* bump thiserror from 1.0.64 to 1.0.66
 
 ## [0.2.1](https://github.com/calteran/oliframe/compare/v0.2.0...v0.2.1) - 2024-10-02
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "oliframe"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "csscolorparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "oliframe"
 description = "Add a simple border to one or more images"
 repository = "https://github.com/calteran/oliframe"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
## 🤖 New release
* `oliframe`: 0.2.1 -> 0.2.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.2](https://github.com/calteran/oliframe/compare/v0.2.1...v0.2.2) - 2024-11-05

### Other

- Merge branch 'develop' into dependabot/cargo/develop/crate-deps-fc6a7a0e96
- remove docs badge
- *(deps)* bump the crate-deps group with 4 updates
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).