### PR TITLE
chore: release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/calteran/oliframe/compare/v0.1.0...HEAD)
 
+## [0.2.3](https://github.com/calteran/oliframe/compare/v0.2.2...v0.2.3) - 2024-12-02
+
+### Other
+- *(deps)* bump clap from 4.5.20 to 4.5.21
+- *(deps)* bump image from 0.25.4 to 0.25.5
+- *(deps)* bump thiserror from 1.0.66 to 2.0.3
+- *(deps)* bump tempfile from 3.13.0 to 3.14.0
+- adjust `deny.toml` for updated licenses & version dups
+
 ## [0.2.2](https://github.com/calteran/oliframe/compare/v0.2.1...v0.2.2) - 2024-11-05
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "oliframe"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "clap",
  "csscolorparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "oliframe"
 description = "Add a simple border to one or more images"
 repository = "https://github.com/calteran/oliframe"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
## 🤖 New release
* `oliframe`: 0.2.2 -> 0.2.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.3](https://github.com/calteran/oliframe/compare/v0.2.2...v0.2.3) - 2024-12-02

### Other

- dependency & ci updates ([#75](https://github.com/calteran/oliframe/pull/75))
- fixed png output verification hash
- *(deps)* adjust `deny.toml` for updated licenses & version dups
- *(deps)* bump the crate-deps group with 4 updates
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).