### PR TITLE
chore: release v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/calteran/oliframe/compare/v0.1.0...HEAD)
 
+## [0.2.4](https://github.com/calteran/oliframe/compare/v0.2.3...v0.2.4) - 2025-01-03
+
+### Other
+
+- *(deps)* bump clap from 4.5.21 to 4.5.23
+- *(deps)* bump env_logger from 0.11.5 to 0.11.6
+- *(deps)* bump thiserror from 2.0.3 to 2.0.9
+- *(deps)* bump xxhash-rust from 0.8.12 to 0.8.15
+
 ## [0.2.3](https://github.com/calteran/oliframe/compare/v0.2.2...v0.2.3) - 2024-12-02
 
 ### Other
+
 - *(deps)* bump clap from 4.5.20 to 4.5.21
 - *(deps)* bump image from 0.25.4 to 0.25.5
 - *(deps)* bump thiserror from 1.0.66 to 2.0.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "oliframe"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "clap",
  "csscolorparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "oliframe"
 description = "Add a simple border to one or more images"
 repository = "https://github.com/calteran/oliframe"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/deny.toml
+++ b/deny.toml
@@ -10,6 +10,15 @@ allow = [
 
 [bans]
 skip = [
-    "thiserror@1.0.69", # Until https://github.com/xiph/rav1e/pull/3403 (image dep)
-    "thiserror-impl@1.0.69" # Until https://github.com/xiph/rav1e/pull/3403 (image dep)
+    "thiserror@1.0.69",
+    #└── rav1e v0.7.1 <- fixed in `master`, but no release yet
+    #    └── ravif v0.11.11
+    #        └── image v0.25.5
+    #            └── oliframe v0.2.4
+    "thiserror-impl@1.0.69"
+    #└── thiserror v1.0.69
+    #    └── rav1e v0.7.1 <- fixed in `master`, but no release yet
+    #        └── ravif v0.11.11
+    #            └── image v0.25.5
+    #                └── oliframe v0.2.4
 ]


### PR DESCRIPTION
## 🤖 New release
* `oliframe`: 0.2.3 -> 0.2.4

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.4](https://github.com/calteran/oliframe/compare/v0.2.3...v0.2.4) - 2025-01-03

### Other

- *(deps)* bump the crate-deps group with 4 updates
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).