### PR TITLE
chore: release v0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/calteran/oliframe/compare/v0.1.0...HEAD)
 
+## [0.2.5](https://github.com/calteran/oliframe/compare/v0.2.4...v0.2.5) - 2025-02-02
+
+### Other
+
+- *(deps)* bump clap from 4.5.23 to 4.5.27
+- *(deps)* bump log from 0.4.22 to 0.4.25
+- *(deps)* bump thiserror from 2.0.9 to 2.0.11
+- *(deps)* bump tempfile from 3.14.0 to 3.16.0
+
 ## [0.2.4](https://github.com/calteran/oliframe/compare/v0.2.3...v0.2.4) - 2025-01-03
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "oliframe"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "clap",
  "csscolorparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "oliframe"
 description = "Add a simple border to one or more images"
 repository = "https://github.com/calteran/oliframe"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `oliframe`: 0.2.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.5](https://github.com/calteran/oliframe/compare/v0.2.4...v0.2.5) - 2025-02-02

### Other

- *(deps)* bump the crate-deps group with 4 updates
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).