### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/calteran/oliframe/compare/v0.1.0...HEAD)
 
+## [0.3.1](https://github.com/calteran/oliframe/compare/v0.3.0...v0.3.1) - 2025-04-02
+
+- *(deps)* bump patch level of clap, env_logger, image, log, and tempfile
+- *(deps)* remove `rav1e` from downline dependencies
+
 ## [0.3.0](https://github.com/calteran/oliframe/compare/v0.2.5...v0.3.0) - 2025-03-04
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,7 +687,7 @@ dependencies = [
 
 [[package]]
 name = "oliframe"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "csscolorparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "oliframe"
 description = "Add a simple border to one or more images"
 repository = "https://github.com/calteran/oliframe"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `oliframe`: 0.3.0 -> 0.3.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/calteran/oliframe/compare/v0.3.0...v0.3.1) - 2025-04-02

### Fixed

- *(test)* update test image hashes

### Other

- *(deps)* remove `rav1e` from downline dependencies
- ignore output directory
- *(deps)* bump the crate-deps group with 5 updates
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).