### PR TITLE
chore: release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/calteran/oliframe/compare/v0.1.0...HEAD)
 
+## [0.3.2](https://github.com/calteran/oliframe/compare/v0.3.1...v0.3.2) - 2025-05-05
+
+### Other
+
+- *(deps)* bump clap from 4.5.35 to 4.5.37 in the crate-deps group
+
 ## [0.3.1](https://github.com/calteran/oliframe/compare/v0.3.0...v0.3.1) - 2025-04-02
 
 - *(deps)* bump patch level of clap, env_logger, image, log, and tempfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
-- *(deps)* bump clap from 4.5.35 to 4.5.37 in the crate-deps group
+- *(deps)* bump clap from 4.5.35 to 4.5.37
 
 ## [0.3.1](https://github.com/calteran/oliframe/compare/v0.3.0...v0.3.1) - 2025-04-02
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,7 +687,7 @@ dependencies = [
 
 [[package]]
 name = "oliframe"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "clap",
  "csscolorparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "oliframe"
 description = "Add a simple border to one or more images"
 repository = "https://github.com/calteran/oliframe"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `oliframe`: 0.3.1 -> 0.3.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.2](https://github.com/calteran/oliframe/compare/v0.3.1...v0.3.2) - 2025-05-05

### Other

- *(deps)* bump clap from 4.5.35 to 4.5.37 in the crate-deps group
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).