### PR TITLE
chore: release v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/calteran/oliframe/compare/v0.1.0...HEAD)
 
+## [0.3.3](https://github.com/calteran/oliframe/compare/v0.3.2...v0.3.3) - 2025-06-02
+
+### Fixed
+
+- *(docs)* fix display of CI status badge in readme
+
+### Other
+
+- *(deps)* bump the patch level of clap and csscolorparser
+- *(deps)* bump tempfile from 3.19.1 to 3.20.0
+
 ## [0.3.2](https://github.com/calteran/oliframe/compare/v0.3.1...v0.3.2) - 2025-05-05
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,7 +687,7 @@ dependencies = [
 
 [[package]]
 name = "oliframe"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "clap",
  "csscolorparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "oliframe"
 description = "Add a simple border to one or more images"
 repository = "https://github.com/calteran/oliframe"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `oliframe`: 0.3.2 -> 0.3.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.3](https://github.com/calteran/oliframe/compare/v0.3.2...v0.3.3) - 2025-06-02

### Fixed

- *(docs)* correct CI status badge URL

### Other

- *(deps)* bump the crate-deps group with 3 updates
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).