### PR TITLE
chore: release v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/calteran/oliframe/compare/v0.1.0...HEAD)
+## [Unreleased]
+
+## [0.3.4](https://github.com/calteran/oliframe/compare/v0.3.3...v0.3.4) - 2025-08-04
+
+### Other
+
+- *(deps)* bump the patch level of clap, csscolorparser, strum and strum-macros
+- inline variables in `format!` calls
 
 ## [0.3.3](https://github.com/calteran/oliframe/compare/v0.3.2...v0.3.3) - 2025-06-02
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,7 +687,7 @@ dependencies = [
 
 [[package]]
 name = "oliframe"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "clap",
  "csscolorparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "oliframe"
 description = "Add a simple border to one or more images"
 repository = "https://github.com/calteran/oliframe"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `oliframe`: 0.3.3 -> 0.3.4

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).