### PR TITLE
chore: release v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.5](https://github.com/calteran/oliframe/compare/v0.3.4...v0.3.5) - 2025-09-07
+
+### Other
+
+- *(deps)* bump rayon from 1.10.0 to 1.11.0
+- *(deps)* bump tempfile from 3.20.0 to 3.21.0
+- *(deps)* bump the patch level of clap, regex and thiserror
+
 ## [0.3.4](https://github.com/calteran/oliframe/compare/v0.3.3...v0.3.4) - 2025-08-04
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,7 +687,7 @@ dependencies = [
 
 [[package]]
 name = "oliframe"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "clap",
  "csscolorparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "oliframe"
 description = "Add a simple border to one or more images"
 repository = "https://github.com/calteran/oliframe"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2024"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `oliframe`: 0.3.4 -> 0.3.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.5](https://github.com/calteran/oliframe/compare/v0.3.4...v0.3.5) - 2025-09-07

### Other

- *(deps)* bump the crate-deps group with 5 updates
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).