### PR TITLE
chore: release v0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.6](https://github.com/calteran/oliframe/compare/v0.3.5...v0.3.6) - 2025-10-06
+
+### Fixed
+
+- adjusted test image hashes due to `image` encoding changes
+
+### Other
+
+- *(deps)* bump tempfile from 3.21.0 to 3.23.0
+- *(deps)* bump the patch level of clap, image, log, regex and thiserror
+
 ## [0.3.5](https://github.com/calteran/oliframe/compare/v0.3.4...v0.3.5) - 2025-09-07
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "oliframe"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "clap",
  "csscolorparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "oliframe"
 description = "Add a simple border to one or more images"
 repository = "https://github.com/calteran/oliframe"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2024"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `oliframe`: 0.3.5 -> 0.3.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.6](https://github.com/calteran/oliframe/compare/v0.3.5...v0.3.6) - 2025-10-06

### Fixed

- adjusted test image hashes due to `image` encoding changes

### Other

- *(deps)* bump the crate-deps group with 6 updates
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).