### PR TITLE
chore: release v0.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.8](https://github.com/calteran/oliframe/compare/v0.3.7...v0.3.8) - 2026-02-02
+
+### Other
+
+- *(deps)* bump tempfile from 3.23.0 to 3.24.0
+- *(deps)* bump patch level of clap, csscolorparser, log and thiserror
+
 ## [0.3.7](https://github.com/calteran/oliframe/compare/v0.3.6...v0.3.7) - 2025-12-02
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "oliframe"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "clap",
  "csscolorparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "oliframe"
 description = "Add a simple border to one or more images"
 repository = "https://github.com/calteran/oliframe"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2024"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `oliframe`: 0.3.7 -> 0.3.8

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.8](https://github.com/calteran/oliframe/compare/v0.3.7...v0.3.8) - 2026-02-02

### Other

- *(deps)* bump the crate-deps group across 1 directory with 5 updates
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).