### PR TITLE
chore: release v0.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
-- *(deps)* bump the crate-deps group with 6 updates
+- *(deps)* bump strum from 0.27.2 to 0.28.0
+- *(deps)* bump strum_macros from 0.27.2 to 0.28.0
+- *(deps)* bump tempfile from 3.24.0 to 3.26.0
+- *(deps)* bump the patch level of clap, env_logger, and regex
 
 ## [0.3.8](https://github.com/calteran/oliframe/compare/v0.3.7...v0.3.8) - 2026-02-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.9](https://github.com/calteran/oliframe/compare/v0.3.8...v0.3.9) - 2026-03-04
+
+### Other
+
+- *(deps)* bump the crate-deps group with 6 updates
+
 ## [0.3.8](https://github.com/calteran/oliframe/compare/v0.3.7...v0.3.8) - 2026-02-02
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "oliframe"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "clap",
  "csscolorparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "oliframe"
 description = "Add a simple border to one or more images"
 repository = "https://github.com/calteran/oliframe"
-version = "0.3.8"
+version = "0.3.9"
 edition = "2024"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `oliframe`: 0.3.8 -> 0.3.9

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.9](https://github.com/calteran/oliframe/compare/v0.3.8...v0.3.9) - 2026-03-04

### Other

- *(deps)* bump the crate-deps group with 6 updates
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).