### PR TITLE
chore: release v0.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
-- *(deps)* combined dependency updates (PRs #109 and #111) ([#112](https://github.com/calteran/oliframe/pull/112))
+- *(deps)* bump rand from 0.9.2 to 0.9.4
+- *(deps)* bump clap from 4.5.60 to 4.6.1
+- *(deps)* bump rayon from 1.11.0 to 1.12.0
+- *(deps)* bump tempfile from 3.26.0 to 3.27.0
+- *(deps)* bump the patch level of csscolorparser, env_logger, and log
 
 ## [0.3.9](https://github.com/calteran/oliframe/compare/v0.3.8...v0.3.9) - 2026-03-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.10](https://github.com/calteran/oliframe/compare/v0.3.9...v0.3.10) - 2026-06-03
+
+### Other
+
+- *(deps)* combined dependency updates (PRs #109 and #111) ([#112](https://github.com/calteran/oliframe/pull/112))
+
 ## [0.3.9](https://github.com/calteran/oliframe/compare/v0.3.8...v0.3.9) - 2026-03-04
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "oliframe"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "clap",
  "csscolorparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "oliframe"
 description = "Add a simple border to one or more images"
 repository = "https://github.com/calteran/oliframe"
-version = "0.3.9"
+version = "0.3.10"
 edition = "2024"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `oliframe`: 0.3.9 -> 0.3.10

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.10](https://github.com/calteran/oliframe/compare/v0.3.9...v0.3.10) - 2026-06-03

### Other

- *(deps)* combined dependency updates (PRs #109 and #111) ([#112](https://github.com/calteran/oliframe/pull/112))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).