### PR TITLE
chore: release v0.3.10 (reformatted changelog)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
-- *(deps)* bump the crate-deps group with 4 updates
-- *(deps)* combined dependency updates (PRs #109 and #111) ([#112](https://github.com/calteran/oliframe/pull/112))
+- *(deps)* bump clap from 4.5.60 to 4.6.1
+- *(deps)* bump rayon from 1.11.0 to 1.12.0
+- *(deps)* bump tempfile from 3.26.0 to 3.27.0
+- *(deps)* bump actions/checkout from 6 to 7
+- *(deps)* bump the patch level of csscolorparser, env_logger, log, regex, and xxhash-rust
 
 ## [0.3.9](https://github.com/calteran/oliframe/compare/v0.3.8...v0.3.9) - 2026-03-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.10](https://github.com/calteran/oliframe/compare/v0.3.9...v0.3.10) - 2026-07-02
+
+### Other
+
+- *(deps)* bump the crate-deps group with 4 updates
+- *(deps)* combined dependency updates (PRs #109 and #111) ([#112](https://github.com/calteran/oliframe/pull/112))
+
 ## [0.3.9](https://github.com/calteran/oliframe/compare/v0.3.8...v0.3.9) - 2026-03-04
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "oliframe"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "clap",
  "csscolorparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "oliframe"
 description = "Add a simple border to one or more images"
 repository = "https://github.com/calteran/oliframe"
-version = "0.3.9"
+version = "0.3.10"
 edition = "2024"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
## Summary

This is the `v0.3.10` release (as generated by release-plz in #116), with the auto-generated `CHANGELOG.md` entries reformatted to match the style used for previous releases.

release-plz produced generic bullets:

```
- *(deps)* bump the crate-deps group with 4 updates
- *(deps)* combined dependency updates (PRs #109 and #111) ([#112](...))
```

These have been expanded into the specific dependency version bumps, following the same convention the maintainer applied in `698d6c2` ("update changelog format for v0.3.9") and used throughout the changelog — named minor/major bumps listed individually, patch-level bumps consolidated into a single line, and no PR-link suffixes:

```
- *(deps)* bump clap from 4.5.60 to 4.6.1
- *(deps)* bump rayon from 1.11.0 to 1.12.0
- *(deps)* bump tempfile from 3.26.0 to 3.27.0
- *(deps)* bump actions/checkout from 6 to 7
- *(deps)* bump the patch level of csscolorparser, env_logger, log, regex, and xxhash-rust
```

The version transitions reflect the net direct-dependency changes across the release range (`v0.3.9...v0.3.10`), covering the combined updates from #112 and the crate-deps group from #115, plus the `actions/checkout` bump from #114 that the auto-generated entry omitted.

## Notes

- Version bumps in `Cargo.toml` / `Cargo.lock` (0.3.9 → 0.3.10) are unchanged from the release-plz PR.
- Only `CHANGELOG.md` was edited relative to #116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcLSZbzha9YjZ2Y8roMhve)_